### PR TITLE
Fix build with msvc2015.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,6 +54,7 @@ target_link_libraries(${CEF_TARGET}
 )
 
 if (OS_WINDOWS)
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -EHsc -Wv:18")
     if (CMAKE_BUILD_TYPE STREQUAL "Release")
       set(d "")
     else() # Debug build
@@ -70,6 +71,7 @@ if (OS_WINDOWS)
       "${_qt5Core_install_prefix}/plugins/platforms/qwindows${d}.lib"
       "Ws2_32.lib"
       "Imm32.lib"
+      "Winmm.lib"
     )
 endif()
 


### PR DESCRIPTION
Ignore warnings about shadowed members.
Enable exceptions.
Link to Winmm.lib for PlaySound.

    C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\INCLUDE\xlocale(341): warning C4530: C++ exception handler used, but unwind semantics are not enabled. Specify /EHsc

    ..\handler.cpp(387): warning C4457: declaration of 'buffer' hides function parameter